### PR TITLE
Add targetted entity to SentinelAttackEvent for API usage

### DIFF
--- a/src/main/java/org/mcmonkey/sentinel/SentinelAttackHelper.java
+++ b/src/main/java/org/mcmonkey/sentinel/SentinelAttackHelper.java
@@ -187,7 +187,7 @@ public class SentinelAttackHelper extends SentinelHelperObject {
             itemHelper.swapToMelee();
         }
         sentinel.chasing = entity;
-        SentinelAttackEvent sat = new SentinelAttackEvent(getNPC());
+        SentinelAttackEvent sat = new SentinelAttackEvent(getNPC(), entity);
         Bukkit.getPluginManager().callEvent(sat);
         if (sat.isCancelled()) {
             if (SentinelPlugin.debugMe) {

--- a/src/main/java/org/mcmonkey/sentinel/events/SentinelAttackEvent.java
+++ b/src/main/java/org/mcmonkey/sentinel/events/SentinelAttackEvent.java
@@ -2,6 +2,7 @@ package org.mcmonkey.sentinel.events;
 
 import net.citizensnpcs.api.event.NPCEvent;
 import net.citizensnpcs.api.npc.NPC;
+import org.bukkit.entity.Entity;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
@@ -20,11 +21,14 @@ public class SentinelAttackEvent extends NPCEvent implements Cancellable {
      */
     private boolean cancelled = false;
 
+    private Entity targetEntity;
+
     /**
      * Constructs the attack event.
      */
-    public SentinelAttackEvent(NPC npc) {
+    public SentinelAttackEvent(NPC npc, Entity targetEntity) {
         super(npc);
+        this.targetEntity = targetEntity;
     }
 
     /**
@@ -55,5 +59,13 @@ public class SentinelAttackEvent extends NPCEvent implements Cancellable {
     @Override
     public void setCancelled(boolean cancelled) {
         this.cancelled = cancelled;
+    }
+
+    /**
+     * Returns the
+     * @return Entity targetted by this NPC
+     */
+    public Entity getTargetEntity() {
+        return targetEntity;
     }
 }


### PR DESCRIPTION
I've expanded the API a tad bit, I'm working on a plugin that hooks into Sentinel to add combat functionality and this is necessary for me, plus this just seemed like something the event would benefit from for other developers.