### PR TITLE
Added support for normal ender pearl usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ These are all valid targets and ignores:
     - (To make a target glow ++ damage it, equip a bow + arm it with spectral arrows!)
 - Snowballs
 - Eggs
-- Ender Pearls (Causes the target to get flung into the air!)
+- Ender Pearls (Teleports to target, can cause the target to get flung into the air if `magic pearls` is true)
 - Skulls (Dangerous wither skull explosions!)
 - CrackShot guns!
 

--- a/src/main/java/org/mcmonkey/sentinel/SentinelPlugin.java
+++ b/src/main/java/org/mcmonkey/sentinel/SentinelPlugin.java
@@ -108,6 +108,11 @@ public class SentinelPlugin extends JavaPlugin {
     public boolean canUseSkull;
 
     /**
+     * Configuration option: whether pearls should apply velocity to target, rather than teleport the thrower.
+     */
+    public boolean enableMagicPearls;
+
+    /**
      * Configuration option: whether to block some events that may cause other plugins to have issues.
      */
     public boolean blockEvents;
@@ -237,6 +242,7 @@ public class SentinelPlugin extends JavaPlugin {
         reloadConfig();
         cleverTicks = getConfig().getInt("random.clever ticks", 10);
         canUseSkull = getConfig().getBoolean("random.skull allowed", true);
+        enableMagicPearls = getConfig().getBoolean("random.magic pearls", true);
         blockEvents = getConfig().getBoolean("random.workaround bukkit events", false);
         alternateDamage = getConfig().getBoolean("random.enforce damage", false);
         workaroundDamage = getConfig().getBoolean("random.workaround damage", false);

--- a/src/main/java/org/mcmonkey/sentinel/SentinelWeaponHelper.java
+++ b/src/main/java/org/mcmonkey/sentinel/SentinelWeaponHelper.java
@@ -10,6 +10,7 @@ import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionData;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionType;
+import org.bukkit.projectiles.ProjectileSource;
 import org.bukkit.util.Vector;
 import org.mcmonkey.sentinel.utilities.SentinelVersionCompat;
 
@@ -194,9 +195,13 @@ public class SentinelWeaponHelper extends SentinelHelperObject {
     public void firePearl(LivingEntity target) {
         sentinel.swingWeapon();
         sentinel.faceLocation(target.getEyeLocation());
-        // TODO: Maybe require entity is-on-ground?
         sentinel.stats_pearlsUsed++;
-        target.setVelocity(target.getVelocity().add(new Vector(0, sentinel.getDamage(true), 0)));
+        if(SentinelPlugin.instance.enableMagicPearls) {
+            // TODO: Maybe require entity is-on-ground?
+            target.setVelocity(target.getVelocity().add(new Vector(0, sentinel.getDamage(true), 0)));
+        } else {
+            getLivingEntity().launchProjectile(EnderPearl.class);
+        }
     }
 
     /**

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -79,6 +79,8 @@ random:
     protected: false
     # Whether skull attack is allowed.
     skull allowed: true
+    # Configuration option: whether pearls should apply velocity to target, rather than teleport the thrower.
+    magic pearls: false
     # How many calculation cycles before an NPC will give up on a good target.
     clever ticks: 10
     # The maximum health value for any given Sentinel NPC.


### PR DESCRIPTION
This changes Ender pearl behavior so Sentinels actually throw them and are teleported. The previous behavior will remain enabled by default if `magic pearls` is not set, or is set to true, but moving forward the default behavior should be pretty close to normal vanilla Minecraft behavior (fair warning, I think this means ender pearls will occasionally spawn endermites that attack NPCs)