### PR TITLE
Fixes possible NPE when getting a Clan

### DIFF
--- a/src/main/java/org/mcmonkey/sentinel/integration/SentinelSimpleClans.java
+++ b/src/main/java/org/mcmonkey/sentinel/integration/SentinelSimpleClans.java
@@ -23,7 +23,7 @@ public class SentinelSimpleClans extends SentinelIntegration {
         try {
             if (prefix.equals("simpleclan") && ent instanceof Player) {
                 Clan clan = SimpleClans.getInstance().getClanManager().getClanByPlayerUniqueId(ent.getUniqueId());
-                if (clan.getName().equalsIgnoreCase(value)) {
+                if (clan != null && clan.getName().equalsIgnoreCase(value)) {
                     return true;
                 }
                 else {


### PR DESCRIPTION
If the Player is not a Clan member, that method will return null.